### PR TITLE
Fix bundler failure for packages that don't provide $out/share or $out/bin

### DIFF
--- a/fpm.nix
+++ b/fpm.nix
@@ -8,14 +8,18 @@
   inherit (pkgs) lib;
 
   install_usr = pkg: ''
-    mkdir -p usr/bin
-    for binary in ${pkg}/bin/*; do
-      ln -sf $binary usr/bin
-    done
+    if [ -d ${pkg}/bin ] && [ "$(ls -A ${pkg}/bin)" ]; then
+      mkdir -p usr/bin
+      for binary in ${pkg}/bin/*; do
+        ln -sf $binary usr/bin
+      done
+    fi
 
-    mkdir -p usr/share
-    cp -Rs ${pkg}/share/ usr/
-    find usr -type d -exec chmod 755 {} +
+    if [ -d ${pkg}/share ] && [ "$(ls -A ${pkg}/share)" ]; then
+      mkdir -p usr/share
+      cp -Rs ${pkg}/share/ usr/
+      find usr -type d -exec chmod 755 {} +
+    fi
   '';
 
   buildInputs = with pkgs; [fpm fakeroot] ++ extraBuildInputs;


### PR DESCRIPTION
Currently, the `install_usr` script fails if the nix package doesn't provide both `$out/share` and `$out/bin`. This PR changes the script to skip those directories if they are empty or do not exist at all.

```
> nix bundle --bundler github:viperML/bundlers#pacman
warning: Git tree '/home/jonas/Code/Rust/nix-rust-template' is dirty
error: builder for '/nix/store/3vdfv2bfknz0k2djjakbfvl1vwvqgw7z-pacman-single-full-nix-rust-template-0.1.0.drv' failed with exit code 1;
       last 5 log lines:
       > patching sources
       > configuring
       > no configure script, doing nothing
       > building
       > cp: cannot stat '/nix/store/gg07qr74mmckb8i7yb4m15n9719khjp4-nix-rust-template-0.1.0/share/': No such file or directory
       For full logs, run 'nix log /nix/store/3vdfv2bfknz0k2djjakbfvl1vwvqgw7z-pacman-single-full-nix-rust-template-0.1.0.drv'.
```